### PR TITLE
RabbitMQ Url changed 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.Erechtheus</groupId>
     <artifactId>rabbitmq-maven-plugin</artifactId>
-    <version>0.1.7</version>
+    <version>0.1.8</version>
     <packaging>maven-plugin</packaging>
 
     <name>RabbitMQ Maven Plugin</name>
@@ -204,6 +204,11 @@
             <artifactId>commons-compress</artifactId>
             <version>${commons.compress.version}</version>
         </dependency>
+	<dependency>
+	  <groupId>org.tukaani</groupId>
+	  <artifactId>xz</artifactId>
+	  <version>1.5</version>
+	</dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.Erechtheus</groupId>
+    <groupId>com.github.jkirsch</groupId>
     <artifactId>rabbitmq-maven-plugin</artifactId>
-    <version>0.1.8</version>
+    <version>0.1.5</version>
     <packaging>maven-plugin</packaging>
 
     <name>RabbitMQ Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.Erechtheus</groupId>
     <artifactId>rabbitmq-maven-plugin</artifactId>
-    <version>0.1.6</version>
+    <version>0.1.7</version>
     <packaging>maven-plugin</packaging>
 
     <name>RabbitMQ Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
 	<dependency>
 	  <groupId>org.tukaani</groupId>
 	  <artifactId>xz</artifactId>
-	  <version>1.5</version>
+	  <version>${org.tukaani.version}</version>
 	</dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -269,6 +269,7 @@
         <plexus.utils.version>3.0.21</plexus.utils.version>
         <commons.io.version>2.3</commons.io.version>
         <commons.compress.version>1.9</commons.compress.version>
+        <org.tukaani.version>1.5</org.tukaani.version>
         <commons.lang.version>3.3.2</commons.lang.version>
         <guava.version>18.0</guava.version>
         <http.client.version>4.4</http.client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.Erechtheus</groupId>
     <artifactId>rabbitmq-maven-plugin</artifactId>
-    <version>0.1.5</version>
+    <version>0.1.6</version>
     <packaging>maven-plugin</packaging>
 
     <name>RabbitMQ Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.jkirsch</groupId>
+    <groupId>com.github.Erechtheus</groupId>
     <artifactId>rabbitmq-maven-plugin</artifactId>
     <version>0.1.5</version>
     <packaging>maven-plugin</packaging>

--- a/src/main/java/com/github/iesen/rabbitmq/plugin/manager/FileUtils.java
+++ b/src/main/java/com/github/iesen/rabbitmq/plugin/manager/FileUtils.java
@@ -5,6 +5,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
 
 import java.io.*;
 import java.net.URL;
@@ -26,6 +27,35 @@ public class FileUtils {
         try {
             GzipCompressorInputStream gzIn = new GzipCompressorInputStream(new BufferedInputStream(new FileInputStream(tarGzipFilePath), BUFFER));
             tarIn = new TarArchiveInputStream(gzIn);
+            // Read entries
+            TarArchiveEntry entry;
+            while ((entry = (TarArchiveEntry) tarIn.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    File f = new File(destPath + File.separator + entry.getName());
+                    f.mkdirs();
+                } else {
+                    int count;
+                    byte data[] = new byte[BUFFER];
+                    FileOutputStream fos = new FileOutputStream(destPath + File.separator + entry.getName());
+                    BufferedOutputStream destOut = new BufferedOutputStream(fos, BUFFER);
+                    while ((count = tarIn.read(data, 0, BUFFER)) != -1) {
+                        destOut.write(data, 0, count);
+                    }
+                    destOut.close();
+                }
+            }
+        } finally {
+            if (tarIn != null) {
+                tarIn.close();
+            }
+        }
+    }
+
+    public static void extractTarXz(String tarXzFilePath, String destPath) throws IOException {
+        TarArchiveInputStream tarIn = null;
+        try {
+            XZCompressorInputStream xzIn = new XZCompressorInputStream(new BufferedInputStream(new FileInputStream(tarXzFilePath), BUFFER));
+            tarIn = new TarArchiveInputStream(xzIn);
             // Read entries
             TarArchiveEntry entry;
             while ((entry = (TarArchiveEntry) tarIn.getNextEntry()) != null) {

--- a/src/main/java/com/github/iesen/rabbitmq/plugin/manager/LinuxRabbitManager.java
+++ b/src/main/java/com/github/iesen/rabbitmq/plugin/manager/LinuxRabbitManager.java
@@ -39,7 +39,7 @@ public class LinuxRabbitManager extends MacRabbitManager {
     public void extractServer() throws MojoExecutionException {
         try {
             String rabbitDownloadUrl = "https://www.rabbitmq.com/releases/rabbitmq-server/v" + RABBITMQ_VERSION +
-               "/rabbitmq-server-generic-unix-" + RABBITMQ_VERSION + ".tar.gz";
+               "/rabbitmq-server-generic-unix-" + RABBITMQ_VERSION + ".tar.xz";
             log.debug("Downloading rabbitmq from " + rabbitDownloadUrl);
             FileUtils.download(rabbitDownloadUrl, RABBITMQ_PARENT_DIR + File.separator + "rabbitmq-server-mac-standalone-" + RABBITMQ_VERSION + ".tar.xz");
             log.debug("Extracting downloaded files");

--- a/src/main/java/com/github/iesen/rabbitmq/plugin/manager/LinuxRabbitManager.java
+++ b/src/main/java/com/github/iesen/rabbitmq/plugin/manager/LinuxRabbitManager.java
@@ -41,9 +41,9 @@ public class LinuxRabbitManager extends MacRabbitManager {
             String rabbitDownloadUrl = "https://www.rabbitmq.com/releases/rabbitmq-server/v" + RABBITMQ_VERSION +
                "/rabbitmq-server-generic-unix-" + RABBITMQ_VERSION + ".tar.gz";
             log.debug("Downloading rabbitmq from " + rabbitDownloadUrl);
-            FileUtils.download(rabbitDownloadUrl, RABBITMQ_PARENT_DIR + File.separator + "rabbitmq-server-mac-standalone-" + RABBITMQ_VERSION + ".tar.gz");
+            FileUtils.download(rabbitDownloadUrl, RABBITMQ_PARENT_DIR + File.separator + "rabbitmq-server-mac-standalone-" + RABBITMQ_VERSION + ".tar.xz");
             log.debug("Extracting downloaded files");
-            FileUtils.extractTarGzip(RABBITMQ_PARENT_DIR + File.separator + "rabbitmq-server-mac-standalone-" + RABBITMQ_VERSION + ".tar.gz", RABBITMQ_PARENT_DIR);
+            FileUtils.extractTarXz(RABBITMQ_PARENT_DIR + File.separator + "rabbitmq-server-mac-standalone-" + RABBITMQ_VERSION + ".tar.xz", RABBITMQ_PARENT_DIR);
             // Give permissions
             ProcessBuilder permissionProcess = new ProcessBuilder("/bin/chmod", "-R", "777", RABBITMQ_PARENT_DIR);
             log.debug("Permission command " + permissionProcess.command());


### PR DESCRIPTION
RabbitMQ Url changed from tar.gz to tar.xz, which requires different compresseion codec (with dependencies).

Apologies for verbose commits...